### PR TITLE
camera: allow udp stream through ffmpeg

### DIFF
--- a/BabbleApp/camera.py
+++ b/BabbleApp/camera.py
@@ -106,7 +106,10 @@ class Camera:
                         if self.cancellation_event.wait(WAIT_TIME):
                             return
                         self.current_capture_source = self.config.capture_source
-                        self.cv2_camera = cv2.VideoCapture(self.current_capture_source)
+                        if self.config.use_ffmpeg == True:
+                            self.cv2_camera = cv2.VideoCapture(self.current_capture_source, cv2.CAP_FFMPEG)
+                        else:
+                            self.cv2_camera = cv2.VideoCapture(self.current_capture_source)
                         if not self.settings.gui_cam_resolution_x == 0: self.cv2_camera.set(cv2.CAP_PROP_FRAME_WIDTH, self.settings.gui_cam_resolution_x)
                         if not self.settings.gui_cam_resolution_y == 0: self.cv2_camera.set(cv2.CAP_PROP_FRAME_HEIGHT, self.settings.gui_cam_resolution_y)
                         if not self.settings.gui_cam_framerate == 0: self.cv2_camera.set(cv2.CAP_PROP_FPS, self.settings.gui_cam_framerate)

--- a/BabbleApp/camera_widget.py
+++ b/BabbleApp/camera_widget.py
@@ -242,14 +242,18 @@ class CameraWidget:
         ):
             print("\033[94m[INFO] New value: {}\033[0m".format(values[self.gui_camera_addr]))
             try:
+                self.config.use_ffmpeg = False
                 # Try storing ints as ints, for those using wired cameras.
                 self.config.capture_source = int(values[self.gui_camera_addr])
             except ValueError:
                 if values[self.gui_camera_addr] == "":
                     self.config.capture_source = None
                 else:
-                    if len(values[self.gui_camera_addr]) > 5 and "http" not in values[self.gui_camera_addr] and ".mp4" not in values[self.gui_camera_addr]: # If http is not in camera address, add it.
-                        self.config.capture_source = f"http://{values[self.gui_camera_addr]}/"   
+                    if len(values[self.gui_camera_addr]) > 5 and "http" not in values[self.gui_camera_addr] and ".mp4" not in values[self.gui_camera_addr] and "udp" not in values[self.gui_camera_addr]: # If http is not in camera address, add it.
+                        self.config.capture_source = f"http://{values[self.gui_camera_addr]}/"
+                    elif "udp" in values[self.gui_camera_addr]:
+                        self.config.use_ffmpeg = True
+                        self.config.capture_source = values[self.gui_camera_addr]
                     else:
                         self.config.capture_source = values[self.gui_camera_addr]
             changed = True

--- a/BabbleApp/config.py
+++ b/BabbleApp/config.py
@@ -20,6 +20,7 @@ class BabbleCameraConfig(BaseModel):
     use_n_calibration: bool = True
     gui_vertical_flip: bool = False
     gui_horizontal_flip: bool = False
+    use_ffmpeg: bool = False
 
 class BabbleSettingsConfig(BaseModel):
     gui_min_cutoff: str = "0.9"


### PR DESCRIPTION
This implements support for UDP protocol which I personally use to stream my GoPro Hero 5 to Project Babble,

if this isn't the desired way to do it, let me know!